### PR TITLE
Highlight the right-click search area

### DIFF
--- a/panoclick.html
+++ b/panoclick.html
@@ -192,17 +192,32 @@
                         'https://mts.googleapis.com/vt?pb=%211m4%211m3%211i{z}%212i{x}%213i{y}%212m8%211e2%212ssvv%214m2%211scc%212s%2A211m3%2A211e3%2A212b1%2A213e2%2A211m3%2A211e10%2A212b1%2A213e2%2A212b1%2A214b1%214m2%211ssvl%212s%2A212b1%213m16%212sen%213sUS%2112m4%211e68%212m2%211sset%212sRoadmap%2112m3%211e37%212m1%211ssmartmaps%2112m4%211e26%212m2%211sstyles%212ss.e%7Cp.c%3A%23ff0000%2Cs.e%3Ag.f%7Cp.c%3A%23bd5f1b%2Cs.e%3Ag.s%7Cp.c%3A%23f7ca9e%2C%215m1%215f2%0A'
                     ], 'tileSize': 256
                 });
-                map.addSource('tile-fill-source', {
+                map.addSource('tile-query-loading-source', {
                     'type': 'geojson',
-                    'data': fill_data
+                    'data': fill_data_loading
+                });
+                map.addSource('tile-query-done-source', {
+                    'type': 'geojson',
+                    'data': fill_data_done
                 });
                 map.addLayer(
                 {
-                    'id': 'tile-fill',
+                    'id': 'tile-fill-loading',
                     'type': 'fill',
-                    'source': 'tile-fill-source',
+                    'source': 'tile-query-loading-source',
                     'paint': {
                         'fill-opacity': 0.1
+                    }
+                }
+                )
+                map.addLayer(
+                {
+                    'id': 'tile-fill-done',
+                    'type': 'fill',
+                    'source': 'tile-query-done-source',
+                    'paint': {
+                        'fill-color': '#00aa00',
+                        'fill-opacity': 0.075
                     }
                 }
                 )
@@ -229,7 +244,8 @@
                 'Official Streetview': ["sv-tiles"],
                 'Unofficial Streetview': ["svugc-tiles"],
                 'Clicked': ['points'],
-                'Portals': ['portals']
+                'Portals': ['portals'],
+                'Queried tiles': ['tile-fill-done']
             };
             let layer_ctrls = Object.fromEntries(
                 Object.entries(label_to_layer_ids).map(([label, layer_ids]) => {
@@ -420,7 +436,11 @@
         }
 
         // Right-click to find markers
-        fill_data = {
+        fill_data_loading = {
+            'type': 'FeatureCollection',
+            'features': []
+        };
+        fill_data_done = {
             'type': 'FeatureCollection',
             'features': []
         };
@@ -462,8 +482,8 @@
                     ]]
                 },
             }
-            fill_data.features.push(polygon);
-            map.getSource('tile-fill-source').setData(fill_data);
+            fill_data_loading.features.push(polygon);
+            map.getSource('tile-query-loading-source').setData(fill_data_loading);
 
             // Fetch the panos at the right-clicked location and add them to the map
             const data = await fetch(
@@ -475,6 +495,12 @@
                 addClickedPoint(point[1], point[0]);
             })
             updateStatus(`Points from tile added. Click 'Execute' to search.`);
+            fill_data_loading.features = fill_data_loading.features.filter((f_p) => {
+                return f_p !== polygon;
+            });
+            fill_data_done.features.push(polygon);
+            map.getSource('tile-query-done-source').setData(fill_data_done);
+            map.getSource('tile-query-loading-source').setData(fill_data_loading);
         }
 
         // Handle map resize
@@ -623,8 +649,8 @@
             clickMarkers.forEach(feature => {
                 if (feature.remove) feature.remove();
             });
-            fill_data.features = [];
-            map.getSource('tile-fill-source').setData(fill_data);
+            fill_data_done.features = [];
+            map.getSource('tile-query-done-source').setData(fill_data_done);
         }
         function clearResultFeatures() {
             resultFeatures.forEach(feature => {

--- a/panoclick.html
+++ b/panoclick.html
@@ -192,6 +192,20 @@
                         'https://mts.googleapis.com/vt?pb=%211m4%211m3%211i{z}%212i{x}%213i{y}%212m8%211e2%212ssvv%214m2%211scc%212s%2A211m3%2A211e3%2A212b1%2A213e2%2A211m3%2A211e10%2A212b1%2A213e2%2A212b1%2A214b1%214m2%211ssvl%212s%2A212b1%213m16%212sen%213sUS%2112m4%211e68%212m2%211sset%212sRoadmap%2112m3%211e37%212m1%211ssmartmaps%2112m4%211e26%212m2%211sstyles%212ss.e%7Cp.c%3A%23ff0000%2Cs.e%3Ag.f%7Cp.c%3A%23bd5f1b%2Cs.e%3Ag.s%7Cp.c%3A%23f7ca9e%2C%215m1%215f2%0A'
                     ], 'tileSize': 256
                 });
+                map.addSource('tile-fill-source', {
+                    'type': 'geojson',
+                    'data': fill_data
+                });
+                map.addLayer(
+                {
+                    'id': 'tile-fill',
+                    'type': 'fill',
+                    'source': 'tile-fill-source',
+                    'paint': {
+                        'fill-opacity': 0.1
+                    }
+                }
+                )
                 map.addLayer(
                 {
                     'id': 'sv-tiles',
@@ -405,11 +419,52 @@
             addClickedPoint(lng, lat);
         }
 
+        // Right-click to find markers
+        fill_data = {
+            'type': 'FeatureCollection',
+            'features': []
+        };
+        // Helper functions for working with tiles
+        // Based on https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+        function coords_from_tile(x, y, z) {
+            const n = 2**z
+            const lon_deg = x / n * 360.0 - 180.0
+            const lat_rad = Math.atan(Math.sinh(Math.PI * (1 - 2 * y / n)))
+            const lat_deg = lat_rad * 180.0 / Math.PI
+            return [lat_deg, lon_deg]
+        }
+        function tile_from_coords(lat, lng, z) {
+            const n = 2**z
+            const x = n * ((lng + 180) / 360)
+            const lat_rad = lat / 180 * Math.PI
+            const y = n * (1 - (Math.log(Math.tan(lat_rad) + 1/Math.cos(lat_rad)) / Math.PI)) / 2
+            return [Math.floor(x), Math.floor(y)]
+        }
         async function handleMapContext(e) {
             const { lng, lat } = e.lngLat;
             // This seems to be an ok heuristic to get the requested tile
             // to match what the user sees
             const z = Math.ceil(map.getZoom())+1;
+
+            // Draw a polygon matching the tile
+            const [x, y] = tile_from_coords(lat, lng, z);
+            const [lat1, lng1] = coords_from_tile(x, y, z);
+            const [lat2, lng2] = coords_from_tile(x+1, y+1, z);
+            const polygon = {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [lng1, lat1],
+                        [lng2, lat1],
+                        [lng2, lat2],
+                        [lng1, lat2],
+                    ]]
+                },
+            }
+            fill_data.features.push(polygon);
+            map.getSource('tile-fill-source').setData(fill_data);
+
             // Fetch the panos at the right-clicked location and add them to the map
             const data = await fetch(
                 `https://irt.jdranczewski.dev/panos?lat=${lat}&lng=${lng}&z=${z}`
@@ -568,6 +623,8 @@
             clickMarkers.forEach(feature => {
                 if (feature.remove) feature.remove();
             });
+            fill_data.features = [];
+            map.getSource('tile-fill-source').setData(fill_data);
         }
         function clearResultFeatures() {
             resultFeatures.forEach(feature => {

--- a/panoclick.html
+++ b/panoclick.html
@@ -472,7 +472,8 @@
             const { lng, lat } = e.lngLat;
             // This seems to be an ok heuristic to get the requested tile
             // to match what the user sees
-            const z = Math.ceil(map.getZoom())+1;
+            let z = Math.ceil(map.getZoom())+1;
+            if (z > 22) z = 22;
 
             // Draw a polygon matching the tile
             const [x, y] = tile_from_coords(lat, lng, z);

--- a/panoclick.html
+++ b/panoclick.html
@@ -203,14 +203,6 @@
                     'type': 'geojson',
                     'data': fill_data_done
                 });
-                map.addSource('tile-query-loading-source', {
-                    'type': 'geojson',
-                    'data': fill_data_loading
-                });
-                map.addSource('tile-query-done-source', {
-                    'type': 'geojson',
-                    'data': fill_data_done
-                });
                 map.addLayer(
                 {
                     'id': 'tile-fill-loading',


### PR DESCRIPTION
Add a highlight box around the right-clicked search tile, so the user can see exactly which bit of the map is being searched for panos.